### PR TITLE
throw more useful exception if $ is not defined in iframe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@
 npm-debug.log
 coverage
 node_modules
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 npm-debug.log
 coverage
 node_modules
+.idea

--- a/lib/functional_mixin.js
+++ b/lib/functional_mixin.js
@@ -586,7 +586,7 @@ function busterFunctionalMixin(testCase, options)
       this.document = this.iframe.contentDocument || this.iframe.contentWindow.document;
       this.$        = this.window.$;
 
-      if (typeof this.$ === 'undefined') {
+      if (typeof this.$ == 'undefined') {
         throw new Error('The iframe was not loaded correctly, please double check that the url you requested is available in your test: ' + src);
       }
 

--- a/lib/functional_mixin.js
+++ b/lib/functional_mixin.js
@@ -586,6 +586,10 @@ function busterFunctionalMixin(testCase, options)
       this.document = this.iframe.contentDocument || this.iframe.contentWindow.document;
       this.$        = this.window.$;
 
+      if (typeof this.$ === 'undefined') {
+        throw new Error('The iframe was not loaded correctly, please double check that the url you requested is available in your test: ' + src);
+      }
+
       this._setEventRoot(this.$(this.document));
 
       // adjust window object with custom handler

--- a/test/test-_loadInIframe.js
+++ b/test/test-_loadInIframe.js
@@ -126,6 +126,16 @@ buster.testCase('_loadInIframe',
       assert.equals(this.testObject.window, this._stubs.window);
       assert.equals(this.testObject.document, this._stubs.document);
       assert.equals(this.testObject.$, this._stubs.$);
+    },
+
+    'Throws an exception if $ is not defined on the iframe': function()
+    {
+      assert.exception(function()
+      {
+        this._stubs.$ = undefined;
+        this._stubs.$.withArgs(this._stubs.document).returns(undefined);
+        this.testObject._loadInIframe(common.iframeUriPath, this._stubs.callback);
+      }.bind(this));
     }
   }
 });

--- a/test/test-_loadInIframe.js
+++ b/test/test-_loadInIframe.js
@@ -128,14 +128,27 @@ buster.testCase('_loadInIframe',
       assert.equals(this.testObject.$, this._stubs.$);
     },
 
-    'Throws an exception if $ is not defined on the iframe': function()
+    'Handles the case of $ not defined':
     {
-      assert.exception(function()
+      setUp: function()
       {
-        this._stubs.$ = undefined;
-        this._stubs.$.withArgs(this._stubs.document).returns(undefined);
+        this._stubs.iframe.contentWindow = {$: undefined};
         this.testObject._loadInIframe(common.iframeUriPath, this._stubs.callback);
-      }.bind(this));
+      },
+
+      'Throws an exception if $ is not defined in the iframe': function()
+      {
+        assert.exception(function()
+        {
+          this._stubs.iframe.onload();
+        }.bind(this), {message: 'The iframe was not loaded correctly, please double check that the url you requested is available in your test: '});
+      },
+
+      tearDown: function()
+      {
+        //restore the original stub
+        this._stubs.iframe = {contentWindow: this._stubs.window, contentDocument: this._stubs.document};
+      }
     }
   }
 });

--- a/test/test-_loadInIframe.js
+++ b/test/test-_loadInIframe.js
@@ -136,18 +136,18 @@ buster.testCase('_loadInIframe',
         this.testObject._loadInIframe(common.iframeUriPath, this._stubs.callback);
       },
 
+      tearDown: function()
+      {
+        //restore the original stub
+        this._stubs.iframe.contentWindow = this._stubs.window;
+      },
+
       'Throws an exception if $ is not defined in the iframe': function()
       {
         assert.exception(function()
         {
           this._stubs.iframe.onload();
         }.bind(this), {message: 'The iframe was not loaded correctly, please double check that the url you requested is available in your test: '});
-      },
-
-      tearDown: function()
-      {
-        //restore the original stub
-        this._stubs.iframe = {contentWindow: this._stubs.window, contentDocument: this._stubs.document};
       }
     }
   }


### PR DESCRIPTION
The idea is to throw a meaningful exception to help the developer find the root cause of this error
